### PR TITLE
Fix type conflict

### DIFF
--- a/app/payments/paynl.php
+++ b/app/payments/paynl.php
@@ -85,7 +85,7 @@ if (defined('PAYMENT_NOTIFICATION')) {
     db_query("INSERT INTO ?:paynl_transactions  ?e", $data);
 
     # Update table order
-    fn_change_order_status($order_id, 'O', '', false);
+    fn_change_order_status($order_id, 'O', '', []);
     $url = $result['transaction']['paymentURL'];
     if (isset($url)) {
         fn_redirect($url, true);


### PR DESCRIPTION
With the new warehouses add-on, the payment method is unusable as it causes a type error:

```
Argument 4 passed to fn_warehouses_change_order_status_before_update_product_amount() must be of the type array, bool given, called in #/cscart/app/functions/fn.control.php on line 123
```

Backtrace:

```
File:	app/functions/fn.control.php
Line:	123
Function:	fn_warehouses_change_order_status_before_update_product_amount

File:	app/functions/fn.cart.php
Line:	2746
Function:	fn_set_hook

File:	app/payments/paynl.php
Line:	108
Function:	fn_change_order_status

File:	app/functions/fn.cart.php
Line:	1802
Function:	include

File:	app/functions/fn.cart.php
Line:	10209
Function:	fn_start_payment

File:	app/controllers/frontend/checkout.php
Line:	397
Function:	fn_checkout_place_order

File:	app/functions/fn.control.php
Line:	722
Function:	include

File:	app/functions/fn.control.php
Line:	458
Function:	fn_run_controller

File:	index.php
Line:	25
Function:	fn_dispatch
```